### PR TITLE
Fix build error with react-native 0.59.0

### DIFF
--- a/npm-package/android/build.gradle
+++ b/npm-package/android/build.gradle
@@ -19,11 +19,11 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 28
     }
     buildTypes {
         release {


### PR DESCRIPTION
Increased compileSdk, buildTools and targetSdk version to be compatible with react native 0.59.0.

Since those versions were also increased in react-native 0.59.0 to 28 the library caused an AAPT packaging error while building.