### PR TITLE
feat: add a podspec to support RN 0.60 autolinking

### DIFF
--- a/npm-package/react-native.config.js
+++ b/npm-package/react-native.config.js
@@ -1,0 +1,3 @@
+// This is added to silence the warning that RN CLI gives about legacy "rnpm".
+// We can remove it once "rnpm" is removed from "package.json".
+module.exports = {};

--- a/npm-package/tealium-react-native.podspec
+++ b/npm-package/tealium-react-native.podspec
@@ -1,0 +1,20 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/Tealium/tealium-react-native.git", :tag => "#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+
+  s.dependency 'React'
+  s.dependency 'TealiumIOS'
+end


### PR DESCRIPTION
RN 0.60 ships with [autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md), which is able to discover setup for CocoaPods based on a Podspec file. 

This diff also adds an empty `react-native.config.js` file to silence the legacy "rnpm" warning (it should be removed soon, but in a major version bump)