### PR TITLE
Share Native Android Libraries

### DIFF
--- a/npm-package/android/build.gradle
+++ b/npm-package/android/build.gradle
@@ -38,6 +38,6 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.tealium:library:5.5.5'
-    implementation 'com.tealium:lifecycle:1.1.2'
+    api 'com.tealium:library:5.5.5'
+    api 'com.tealium:lifecycle:1.1.2'
 }


### PR DESCRIPTION
This change is needed to be able to import 'com.tealium' in my application in native Android in order make remote command work in the native android side, without having to import it again in my application's build.gradle.