### PR TITLE
fix(android): lifecycle crashing when instance is not found in onHostPause

### DIFF
--- a/android/TealiumModule.java
+++ b/android/TealiumModule.java
@@ -395,6 +395,10 @@ public class TealiumModule extends ReactContextBaseJavaModule {
                                 public void run() {
                                     if (mIsLifecycleAutotracking) {
                                         LifeCycle lf = LifeCycle.getInstance(instanceName);
+                                        if (lf == null) {
+                                            Log.e(BuildConfig.TAG, "Couldn't find LifeCycle instance named: " + instanceName);
+                                            return;
+                                        }
                                         Map<String, Object> data = new HashMap<>();
                                         data.put("autotracked", "true");
                                         lf.trackLaunchEvent(data);
@@ -406,6 +410,10 @@ public class TealiumModule extends ReactContextBaseJavaModule {
                 } else {
                     if (mIsLifecycleAutotracking) {
                         LifeCycle lf = LifeCycle.getInstance(instanceName);
+                        if (lf == null) {
+                            Log.e(BuildConfig.TAG, "Couldn't find LifeCycle instance named: " + instanceName);
+                            return;
+                        }
                         Map<String, Object> data = new HashMap<>();
                         data.put("autotracked", "true");
                         lf.trackWakeEvent(data);
@@ -417,6 +425,10 @@ public class TealiumModule extends ReactContextBaseJavaModule {
             public void onHostPause() {
                 if (mIsLifecycleAutotracking) {
                     LifeCycle lf = LifeCycle.getInstance(instanceName);
+                    if (lf == null) {
+                        Log.e(BuildConfig.TAG, "Couldn't find LifeCycle instance named: " + instanceName);
+                        return;
+                    }
                     Map<String, Object> data = new HashMap<>();
                     data.put("autotracked", "true");
                     lf.trackSleepEvent(data);


### PR DESCRIPTION
## Summary

I've bumped into a crash report coming from Android 9 and 10 devices (samsungs, moto, oneplus, nokia and some more) that I can't reproduce on my devices:

```
com.tealiumreactnative.TealiumModule$1.onHostPause
java.lang.NullPointerException: Attempt to invoke virtual method 'void com.tealium.lifecycle.LifeCycle.trackSleepEvent(java.util.Map)' on a null object reference
```

The crash happens on v1.0.6, but after upgrading to the latest v1.0.10, the code around the crash is mostly the same, so I assume it's going to happen still. 

To mitigate the crash, I'm adding null checks before accessing the LifeCycle instance, same as it's done for Tealium instances.