### PR TITLE
Fix Xcode 12 compatibility

### DIFF
--- a/npm-package/tealium-react-native.podspec
+++ b/npm-package/tealium-react-native.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,swift}"
   s.requires_arc = true
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "TealiumIOS", "5.6.6"
   s.dependency "TealiumIOSLifecycle", "5.6.6"
 end


### PR DESCRIPTION
## Summary

Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: [facebook/react-native#29633 (comment)](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116)

## Test Plan

Use this branch to install with an app running on Xcode 12.