### PR TITLE
[Crash prevent] Add check to verify if keys are present on TealiumConfig object.

### DIFF
--- a/npm-package/android/src/main/java/com/tealium/react/Extensions.kt
+++ b/npm-package/android/src/main/java/com/tealium/react/Extensions.kt
@@ -58,43 +58,54 @@ fun ReadableMap.toTealiumConfig(application: Application): TealiumConfig? {
     }
 
     val collectors = getArray(KEY_CONFIG_COLLECTORS)?.toCollectorFactories()
-    val modules = getArray(KEY_CONFIG_MODULES)?.toModuleFactories()
     val dispatchers = getArray(KEY_CONFIG_DISPATCHERS)?.toDispatcherFactories()
 
     val config = TealiumConfig(application, account, profile, environment,
             collectors = collectors ?: Collectors.core,
-            modules = modules ?: mutableSetOf(),
+            modules = mutableSetOf(),
             dispatchers = dispatchers ?: mutableSetOf())
 
 
     config.apply {
         // Data Source Id
-        getString(KEY_CONFIG_DATA_SOURCE)?.let {
-            dataSourceId = it
+        if (hasKey(KEY_CONFIG_DATA_SOURCE)) {
+            getString(KEY_CONFIG_DATA_SOURCE)?.let {
+                dataSourceId = it
+            }
         }
 
         // Collect Settings
-        getString(KEY_COLLECT_OVERRIDE_URL)?.let {
-            overrideCollectUrl = it
+        if (hasKey(KEY_COLLECT_OVERRIDE_URL)) {
+            getString(KEY_COLLECT_OVERRIDE_URL)?.let {
+                overrideCollectUrl = it
+            }
         }
-        getString(KEY_COLLECT_OVERRIDE_BATCH_URL)?.let {
-            overrideCollectBatchUrl = it
+        if (hasKey(KEY_COLLECT_OVERRIDE_BATCH_URL)) {
+            getString(KEY_COLLECT_OVERRIDE_BATCH_URL)?.let {
+                overrideCollectBatchUrl = it
+            }
         }
-        getString(KEY_COLLECT_OVERRIDE_DOMAIN)?.let {
-            overrideCollectDomain = it
+        if (hasKey(KEY_COLLECT_OVERRIDE_DOMAIN)) {
+            getString(KEY_COLLECT_OVERRIDE_DOMAIN)?.let {
+                overrideCollectDomain = it
+            }
         }
 
         // Library Settings
         if (hasKey(KEY_SETTINGS_USE_REMOTE)) {
             useRemoteLibrarySettings = getBoolean(KEY_SETTINGS_USE_REMOTE)
         }
-        getString(KEY_SETTINGS_OVERRIDE_URL)?.let {
-            overrideLibrarySettingsUrl = it
+        if (hasKey(KEY_SETTINGS_OVERRIDE_URL)) {
+            getString(KEY_SETTINGS_OVERRIDE_URL)?.let {
+                overrideLibrarySettingsUrl = it
+            }
         }
 
         // Tag Management
-        getString(KEY_TAG_MANAGEMENT_OVERRIDE_URL)?.let {
-            overrideTagManagementUrl = it
+        if (hasKey(KEY_TAG_MANAGEMENT_OVERRIDE_URL)) {
+            getString(KEY_TAG_MANAGEMENT_OVERRIDE_URL)?.let {
+                overrideTagManagementUrl = it
+            }
         }
 
         // Deep Links
@@ -106,29 +117,37 @@ fun ReadableMap.toTealiumConfig(application: Application): TealiumConfig? {
         }
 
         // Log Level
-        getString(KEY_LOG_LEVEL)?.let {
-            Logger.logLevel = LogLevel.fromString(it)
+        if (hasKey(KEY_LOG_LEVEL)) {
+            getString(KEY_LOG_LEVEL)?.let {
+                Logger.logLevel = LogLevel.fromString(it)
+            }
         }
 
         // Consent
         if (hasKey(KEY_CONSENT_LOGGING_ENABLED)) {
             consentManagerLoggingEnabled = getBoolean(KEY_CONSENT_LOGGING_ENABLED)
         }
-        getString(KEY_CONSENT_LOGGING_URL)?.let {
-            consentManagerLoggingUrl = it
+        if (hasKey(KEY_CONSENT_LOGGING_URL)) {
+            getString(KEY_CONSENT_LOGGING_URL)?.let {
+                consentManagerLoggingUrl = it
+            }
         }
 
-        getMap(KEY_CONSENT_EXPIRY)?.let { map ->
-            map.getDouble(KEY_CONSENT_EXPIRY_TIME).let { time ->
-                map.getString(KEY_CONSENT_EXPIRY_UNIT)?.let { unit ->
-                    consentExpiry = consentExpiryFromValues(time.toLong(), unit)
+        if (hasKey(KEY_CONSENT_EXPIRY)) {
+            getMap(KEY_CONSENT_EXPIRY)?.let { map ->
+                map.getDouble(KEY_CONSENT_EXPIRY_TIME).let { time ->
+                    map.getString(KEY_CONSENT_EXPIRY_UNIT)?.let { unit ->
+                        consentExpiry = consentExpiryFromValues(time.toLong(), unit)
+                    }
                 }
             }
         }
 
-        getString(KEY_CONSENT_POLICY)?.let {
-            consentManagerEnabled = true
-            consentManagerPolicy = consentPolicyFromString(it)
+        if (hasKey(KEY_CONSENT_POLICY)) {
+            getString(KEY_CONSENT_POLICY)?.let {
+                consentManagerEnabled = true
+                consentManagerPolicy = consentPolicyFromString(it)
+            }
         }
 
         // Lifecycle


### PR DESCRIPTION
App is crashing at Tealium initialisation when we don't provide some properties on TealiumConfig object.
1st issue: We are trying to get the KEY_CONFIG_MODULES key from TealiumConfig properties, however we can't give this key... Has it be forgotten or so ..?
It causes a crash.
2nd issue: 
As we can see, the param values of getString(), getArray() ... methods can't be null.
It causes a crash.
![Screenshot 2021-03-01 at 10 05 44](https://user-images.githubusercontent.com/43854172/109668668-ada93300-7b71-11eb-8f6d-8203bde36a10.png)

So this pull request is about to remove the "try to get modules key" & check if the key is present before trying to get it.
