### PR TITLE
Fix TS declaration according to API ref.

### DIFF
--- a/npm-package/index.d.ts
+++ b/npm-package/index.d.ts
@@ -25,7 +25,7 @@ declare module 'tealium-react-native' {
 		 * Sets up a remote command for later execution
 		 * @param id The ID used to invoke the remote command
 		 */
-		public static addRemoteCommand(id: string): void;
+		public static addRemoteCommand(id: string, callback: (payload: Record<string, unknown>) => void): void;
 
 		/**
 		 * Removes a remote command


### PR DESCRIPTION
There is a mismatch between [API reference](https://docs.tealium.com/platforms/react-native/api/#addRemoteCommand) and the Typescript declaration, resulting in compilation errors:

![image](https://user-images.githubusercontent.com/6213695/121023695-d14ccc80-c7a3-11eb-8fb8-c8ec779be1d1.png)
