### PR TITLE
Fix pod warnings in regards to wrongly defined license file path

### DIFF
--- a/npm-package/tealium-react-native-swift.podspec
+++ b/npm-package/tealium-react-native-swift.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
                   Tealium React Native Plugin
                    DESC
   s.homepage = "https://github.com/tealium/tealium-react-native"
-  s.license = { :type => "Commercial", :file => "LICENSE.txt" }
+  s.license = { :type => "Commercial", :file => "LICENSE" }
   s.authors = { "Christina Sund" => "christina.sund@tealium.com", "James Keith" => "james.keith@tealium.com" }
   s.platforms = { :ios => "11.0" }
   s.source = { :git => "https://github.com/tealium/tealium-react-native.git", :tag => "#{s.version}" }

--- a/npm-package/tealium-react-native.podspec
+++ b/npm-package/tealium-react-native.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
                   Tealium React Native Plugin
                    DESC
   s.homepage = "https://github.com/tealium/tealium-react-native"
-  s.license = { :type => "Commercial", :file => "LICENSE.txt" }
+  s.license = { :type => "Commercial", :file => "LICENSE" }
   s.authors = { "Christina Sund" => "christina.sund@tealium.com", "James Keith" => "james.keith@tealium.com" }
   s.platforms = { :ios => "11.0" }
   s.source = { :git => "https://github.com/tealium/tealium-react-native.git", :tag => "#{s.version}" }


### PR DESCRIPTION
This PR fixes podfile warnings when running `pod install` using the latest stable version 2.2.2.

```
[!] A license was specified in podspec `tealium-react-native` but the file does not exist - /Users/alex/Documents/Projects/myapp/node_modules/tealium-react-native/LICENSE.txt

[!] A license was specified in podspec `tealium-react-native-swift` but the file does not exist - /Users/alex/Documents/Projects/myapp/node_modules/tealium-react-native/LICENSE.txt

[!] Unable to read the license file `LICENSE.txt` for the spec `tealium-react-native (2.2.2)`

[!] Unable to read the license file `LICENSE.txt` for the spec `tealium-react-native-swift (2.2.2)`

[!] Unable to read the license file `LICENSE.txt` for the spec `tealium-react-native (2.2.2)`

[!] Unable to read the license file `LICENSE.txt` for the spec `tealium-react-native-swift (2.2.2)`
```