### PR TITLE
[MT-1279] Kotlin Core 1.5.3 dependency + 2.3.1 Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [Full documentation](https://docs.tealium.com/platforms/react-native/install/)
 
+- 2.3.1
+  - Android-Kotlin dependencies updated including severa fixes listed below.
+    - Core 1.5.3, Visitor Service 1.2.0 and Lifecycle 1.2.0
+    - Fix: Some event sending delayed by Visitor Service updates
+    - Fix: Lifecycle negative values
+    - Fix: ModuleManager crashes caused by concurrent modification
+
 - 2.3.0
   - Visitor Switching support
   - Kotlin/Swift SDK dependencies updated

--- a/npm-package/android/build.gradle
+++ b/npm-package/android/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'  // From node_modules
 
     //Tealium
-    implementation 'com.tealium:kotlin-core:1.5.2'
+    implementation 'com.tealium:kotlin-core:1.5.3'
     implementation 'com.tealium:kotlin-collect-dispatcher:1.1.0'
     implementation 'com.tealium:kotlin-tagmanagement-dispatcher:1.2.0'
     implementation 'com.tealium:kotlin-remotecommand-dispatcher:1.2.1'


### PR DESCRIPTION
- Android-Kotlin dependencies updated including severa fixes listed below.
    - Core 1.5.3, Visitor Service 1.2.0 and Lifecycle 1.2.0
    - Fix: Some event sending delayed by Visitor Service updates
    - Fix: Lifecycle negative values
    - Fix: ModuleManager crashes caused by concurrent modification