### PR TITLE
fix: jvm mismatch error in react native projects using latest agp

### DIFF
--- a/npm-package/android/build.gradle
+++ b/npm-package/android/build.gradle
@@ -60,15 +60,6 @@ android {
     lintOptions {
         abortOnError false
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
-    }
 }
 
 repositories {


### PR DESCRIPTION
On trying to add the Tealium SDK, in the a new React Native (version 0.73.3) project, the below error occurs:

```
Execution failed for task ':tealium-react-native:compileDebugKotlin'.
> 'compileDebugJavaWithJavac' task (current target is 17) and 'compileDebugKotlin' task (current target is 11)
jvm target compatibility should be set to the same Java version.
```

It's not possible (or ideal) to run the project using Java 11 since the gradle plugin requires Java 17.

This PR tries to fix the above mentioned [issue](https://github.com/Tealium/tealium-react-native/issues/170).

resolves: #170 