### PR TITLE
Fix runtime error in TealiumReactFirebase.swift during app launch.

### DIFF
--- a/remotecommands/tealium-react-firebase/ios/TealiumReactFirebase.swift
+++ b/remotecommands/tealium-react-firebase/ios/TealiumReactFirebase.swift
@@ -17,7 +17,7 @@ class TealiumReactFirebase: NSObject, RCTBridgeModule {
     let factory = FirebaseRemoteCommandWrapper()
     
     // no longer needed.
-    weak var bridge: RCTBridge?
+    // weak var bridge: RCTBridge?
     
     @objc
     static func requiresMainQueueSetup() -> Bool {


### PR DESCRIPTION
"Fix runtime error in TealiumReactFirebase.swift during app launch. If we do not uncomment this line, we encounter the following error in Xcode when running the app on iOS.Please see the screenshot below for reference."
![Screenshot 2024-10-03 at 10 54 07 AM](https://github.com/user-attachments/assets/2959e8c7-d9de-4a9c-a3f0-d225cd717c4f)
